### PR TITLE
Fix missing entities module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,20 +1,22 @@
 import os
-from setuptools import setup
+from setuptools import setup, find_packages
+
 
 # Thanks Frankkkkk for inspiring.
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
+
 setup(
-    name = "barry-energy-api",
-    version = "1.0.0",
-    author = "Emil Elkjær Nielsen",
-    author_email = "emil@evsn.dk",
-    description = ("Connecting to and getting data from Barry Energy's API (http://barry.energy)"),
-    license = "LICENS",
-    keywords = "python barry energy api electricity prices barry.energy",
-    url = "https://github.com/eelkjaer/BarryAPIClient",
-    packages=['barry_energy_api'],
+    name="barry-energy-api",
+    version="1.0.0",
+    author="Emil Elkjær Nielsen",
+    author_email="emil@evsn.dk",
+    description=("Connecting to and getting data from Barry Energy's API (http://barry.energy)"),
+    license="LICENS",
+    keywords="python barry energy api electricity prices barry.energy",
+    url="https://github.com/eelkjaer/BarryAPIClient",
+    packages=find_packages(),
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",
     install_requires=[],


### PR DESCRIPTION
Hello, when installing package from Pypi, the entities sub-module is missing. It can be fixed by using the automatic discovery from setuptools.
